### PR TITLE
Fixes #1 and #2

### DIFF
--- a/graphql/execute.lua
+++ b/graphql/execute.lua
@@ -170,9 +170,8 @@ local function completeValue(fieldType, result, subSelections, context)
     end
 
     local values = {}
-
-    for i, value in ipairs(values) do
-      values[i] = completeValue(innerType, value, context)
+    for i, value in ipairs(result) do
+      values[i] = completeValue(innerType, value, subSelections, context)
     end
 
     return values

--- a/graphql/rules.lua
+++ b/graphql/rules.lua
@@ -186,7 +186,13 @@ end
 
 function rules.requiredArgumentsPresent(node, context)
   local arguments = node.arguments or {}
-  local parentField = context.objects[#context.objects - 1].fields[node.name.value]
+  local parentField
+  if context.objects[#context.objects - 1].__type == 'List' then
+    parentField = context.objects[#context.objects - 2].fields[node.name.value]
+  else
+    parentField = context.objects[#context.objects - 1].fields[node.name.value]
+  end
+
   for name, argument in pairs(parentField.arguments) do
     if argument.__type == 'NonNull' then
       local present = util.find(arguments, function(argument)

--- a/graphql/schema.lua
+++ b/graphql/schema.lua
@@ -24,6 +24,8 @@ function schema.create(config)
   self.directiveMap = {}
 
   local function generateTypeMap(node)
+    if self.typeMap[node.name] and self.typeMap[node.name] == node then return end
+
     if node.__type == 'NonNull' or node.__type == 'List' then
       return generateTypeMap(node.ofType)
     end
@@ -43,6 +45,7 @@ function schema.create(config)
     end
 
     if node.__type == 'Object' or node.__type == 'Interface' or node.__type == 'InputObject' then
+      if type(node.fields) == 'function' then node.fields = node.fields() end
       for fieldName, field in pairs(node.fields) do
         if field.arguments then
           for _, argument in pairs(field.arguments) do

--- a/graphql/util.lua
+++ b/graphql/util.lua
@@ -73,4 +73,14 @@ function util.coerceValue(node, schemaType, variables)
   end
 end
 
+function util.compose (f,g)
+    return function(...) return f(g(...)) end
+end
+
+function util.bind1(func, val1)
+  return function (val2)
+    return func(val1, val2)
+  end
+end
+
 return util

--- a/graphql/validate.lua
+++ b/graphql/validate.lua
@@ -58,7 +58,12 @@ local visitors = {
 
   field = {
     enter = function(node, context)
-      local parentField = context.objects[#context.objects].fields[node.name.value]
+      local parentField
+      if context.objects[#context.objects].__type == 'List' then
+        parentField = context.objects[#context.objects - 1].fields[node.name.value]
+      else
+        parentField = context.objects[#context.objects].fields[node.name.value]
+      end
 
       -- false is a special value indicating that the field was not present in the type definition.
       local field = parentField and parentField.kind or false


### PR DESCRIPTION
This pr fixes a bug that prevents a field defined like this from working properly

```
tasks = {
        kind = types.list(Task),
        resolve = function(project, arguments)
          return getTasksByProjectId(project.id)
        end
}
```

This PR allows defining the fields like this, which is useful when there are circular references

```
fields = function()
    return {
      id = types.id.nonNull,
      name = types.string.nonNull,
      projects = {
        kind = types.list(Project),
        resolve = function(client, arguments)
          return getProjectByClientId(client.id)
        end
      }
    }
end
```

PS: I'm not a lua developer and i don't quite fully understand the codebase so please review this PR and i will make the appropriate changes for it to be merged.
