### PR TITLE
Fix bug coercing arguments that are lists

### DIFF
--- a/graphql/util.lua
+++ b/graphql/util.lua
@@ -66,7 +66,7 @@ function util.coerceValue(node, schemaType, variables)
     end
 
     return util.map(node.values, function(value)
-      return util.coerceValue(node.values[i], schemaType.ofType, variables)
+      return util.coerceValue(value, schemaType.ofType, variables)
     end)
   end
 


### PR DESCRIPTION
This would previously result in an empty list or error. This looks like it was just missed when converting from a for loop into using `util.map`.