### PR TITLE
Add simple subscription type to satisfy clients that use a newer spec

### DIFF
--- a/graphql/introspection.lua
+++ b/graphql/introspection.lua
@@ -44,7 +44,15 @@ __Schema = types.object({
         resolve = function(schema)
           return schema.directives
         end
-      }
+      },
+
+      subscriptionType = {
+        description = 'If this server supports subscriptions, the type that subscription operations will be rooted at',
+        kind = __Type,
+        resolve = function(schema)
+          return schema:getSubscriptionType()
+        end
+       }
     }
   end
 })

--- a/graphql/schema.lua
+++ b/graphql/schema.lua
@@ -26,6 +26,7 @@ function schema.create(config)
 
   self:generateTypeMap(self.query)
   self:generateTypeMap(self.mutation)
+  self:generateTypeMap(self.subscription)
   self:generateTypeMap(introspection.__Schema)
   self:generateDirectiveMap()
 
@@ -97,6 +98,10 @@ end
 
 function schema:getMutationType()
   return self.mutation
+end
+
+function schema:getSubscriptionType()
+  return self.subscription
 end
 
 function schema:getTypeMap()


### PR DESCRIPTION
Specifically, this helps GraphiQL avoid an extra query to fill its interface.