### PR TITLE
Custom JSON Serialization of Empty Objects

### DIFF
--- a/graphql/execute.lua
+++ b/graphql/execute.lua
@@ -175,7 +175,7 @@ local function completeValue(fieldType, result, subSelections, context)
       values[i] = completeValue(innerType, value, subSelections, context)
     end
 
-    return values
+    return next(values) and values or context.schema.__emptyList
   end
 
   if fieldTypeName == 'Scalar' or fieldTypeName == 'Enum' then
@@ -183,7 +183,8 @@ local function completeValue(fieldType, result, subSelections, context)
   end
 
   if fieldTypeName == 'Object' then
-    return evaluateSelections(fieldType, result, subSelections, context)
+    local fields = evaluateSelections(fieldType, result, subSelections, context)
+    return next(fields) and fields or context.schema.__emptyObject
   elseif fieldTypeName == 'Interface' or fieldTypeName == 'Union' then
     local objectType = fieldType.resolveType(result)
     return evaluateSelections(objectType, result, subSelections, context)

--- a/graphql/schema.lua
+++ b/graphql/schema.lua
@@ -5,6 +5,9 @@ local introspection = require(path .. '.introspection')
 local schema = {}
 schema.__index = schema
 
+schema.__emptyList = {}
+schema.__emptyObject = {}
+
 function schema.create(config)
   assert(type(config.query) == 'table', 'must provide query object')
   assert(not config.mutation or type(config.mutation) == 'table', 'mutation must be a table if provided')


### PR DESCRIPTION
Adds `__emptyList` and `__emptyObject` keys to schemas to allow customization of empty lists and objects, which will otherwise both map to an empty Lua table.

Fixes #14 