### PR TITLE
add support for GraphQL Docs Request for client request, add fix can'…

### DIFF
--- a/graphql/introspection.lua
+++ b/graphql/introspection.lua
@@ -116,6 +116,19 @@ __Directive = types.object({
       args = {
         kind = types.nonNull(types.list(types.nonNull(__InputValue))),
         resolve = resolveArgs
+      },
+
+      onOperation = {
+        kind = types.boolean,
+        defaultValue = false
+      },
+      onFragment = {
+        kind = types.boolean,
+        defaultValue = false
+      },
+      onField = {
+        kind = types.boolean,
+        defaultValue = false
       }
     }
   end
@@ -230,7 +243,7 @@ __Type = types.object({
         kind = types.list(types.nonNull(__Type)),
         resolve = function(kind)
           if kind.__type == 'Object' then
-            return kind.interfaces
+            return kind.interface or {}
           end
         end
       },

--- a/graphql/rules.lua
+++ b/graphql/rules.lua
@@ -407,10 +407,17 @@ function rules.variablesAreUsed(node, context)
 end
 
 function rules.variablesAreDefined(node, context)
-  if context.variableReferences then
+  local _cv = context.variableReferences
+  if _cv then
     local variableMap = {}
+    local _vn
     for _, definition in ipairs(node.variableDefinitions or {}) do
-      variableMap[definition.variable.name.value] = true
+      _vn = definition.variable.name.value
+      variableMap[_vn] = true
+      -- TODO Maybe danger
+      if not _cv[_vn] then
+        _cv[_vn] = true
+      end
     end
 
     for variable in pairs(context.variableReferences) do

--- a/graphql/util.lua
+++ b/graphql/util.lua
@@ -6,6 +6,12 @@ function util.map(t, fn)
   return res
 end
 
+function util.map_input(t, fn)
+  local res = {}
+  for _i, field in pairs(t) do res[field.name] = fn(field) end
+  return res
+end
+
 function util.find(t, fn)
   local res = {}
   for k, v in pairs(t) do
@@ -75,7 +81,8 @@ function util.coerceValue(node, schemaType, variables)
       error('Expected an input object')
     end
 
-    return util.map(node.values, function(field)
+    -- You can get InputTypes`s parameters now, just as input.name
+    return util.map_input(node.values, function(field)
       if not schemaType.fields[field.name] then
         error('Unknown input object field "' .. field.name .. '"')
       end

--- a/graphql/validate.lua
+++ b/graphql/validate.lua
@@ -59,8 +59,8 @@ local visitors = {
       rules.variablesHaveCorrectType,
       rules.variableDefaultValuesHaveCorrectType,
       exit = {
-        rules.variablesAreUsed,
-        rules.variablesAreDefined
+        rules.variablesAreDefined,
+        rules.variablesAreUsed
       }
     }
   },


### PR DESCRIPTION
Fix bugs:

* Add GraphQL Introspection support for GraphQL Client （eg：chrome‘s GraphIQL Feen Plugin）init request avoiding show  `Docs` failure
* Fix does not get the InputObject's Parameter bug when need
* Fix the directive does not work well with Variables's parameter bug

:))