### PR TITLE
GraphIQL missing interfaces

### DIFF
--- a/graphql/introspection.lua
+++ b/graphql/introspection.lua
@@ -230,7 +230,7 @@ __Type = types.object({
         kind = types.list(types.nonNull(__Type)),
         resolve = function(kind)
           if kind.__type == 'Object' then
-            return kind.interfaces
+            return kind.interfaces or {}
           end
         end
       },


### PR DESCRIPTION
When trying to use a host made using graphql-lua, graphiql is missing the interfaces.
Apparently this is a common issue, as explained here: https://github.com/graphql/graphiql/issues/746#issuecomment-440849959